### PR TITLE
feat: add German translations for video dialog and tooltip

### DIFF
--- a/src/locales/de.ts
+++ b/src/locales/de.ts
@@ -51,7 +51,11 @@ const locale: Record<string, string> = {
   'editor.image.dialog.tab.url': 'URL',
   'editor.image.dialog.tab.upload': 'Hochladen',
   'editor.image.dialog.form.link': 'Link',
-  'editor.image.dialog.form.alt': 'Alt'
+  'editor.image.dialog.form.alt': 'Alt',
+  'editor.video.tooltip': 'Video',
+  'editor.video.dialog.title': 'Video einfügen',
+  'editor.video.dialog.link': 'link',
+  'editor.video.dialog.button.apply': 'Anwenden',
 }
 
 export default locale

--- a/src/locales/de.ts
+++ b/src/locales/de.ts
@@ -52,10 +52,14 @@ const locale: Record<string, string> = {
   'editor.image.dialog.tab.upload': 'Hochladen',
   'editor.image.dialog.form.link': 'Link',
   'editor.image.dialog.form.alt': 'Alt',
+  'editor.image.dialog.form.aspectRatio': 'Original-Seitenverhältnis beibehalten',
+  'editor.image.dialog.button.apply': 'Anwenden',
   'editor.video.tooltip': 'Video',
   'editor.video.dialog.title': 'Video einfügen',
   'editor.video.dialog.link': 'link',
   'editor.video.dialog.button.apply': 'Anwenden',
+  'editor.undo.tooltip': 'Rückgängig',
+  'editor.redo.tooltip': 'Wiederholen',
 }
 
 export default locale


### PR DESCRIPTION
Add German translations for video dialog within the de.ts file. Verified by a German speaker!