### PR TITLE
fix: disableToolbar prop not behaving reactively

### DIFF
--- a/src/components/VuetifyTiptap.vue
+++ b/src/components/VuetifyTiptap.vue
@@ -9,7 +9,7 @@ import { VuetifyTiptapOnChange } from '@/type'
 import { differenceBy, getCssUnitWithDefault, hasExtension, isBoolean, isEqual, throttle } from '@/utils/utils'
 
 import { Editor, EditorContent } from '@tiptap/vue-3'
-import { computed, onUnmounted, provide, unref, useAttrs, watch } from 'vue'
+import { computed, onUnmounted, provide, toRef, unref, useAttrs, watch } from 'vue'
 import { useTheme } from 'vuetify'
 import BubbleMenu from './BubbleMenu.vue'
 import TipTapToolbar from './TiptapToolbar.vue'
@@ -194,7 +194,7 @@ watch(() => props.disabled, onDisabledChange)
 
 onUnmounted(() => editor?.destroy())
 
-provide('disableToolbar', props.disableToolbar)
+provide('disableToolbar', toRef(() => props.disableToolbar))
 
 defineExpose({ editor })
 </script>

--- a/src/extensions/components/ActionButton/src/index.vue
+++ b/src/extensions/components/ActionButton/src/index.vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
 import { getIcon } from '@/constants/icons'
-import { inject } from 'vue'
+import { inject, ref, type Ref } from 'vue'
 import { actionButtonProps } from './props'
 
 const props = defineProps(actionButtonProps)
 
-const disableToolbar = inject<boolean>('disableToolbar', false)
+const disableToolbar = inject<Readonly<Ref<boolean>>>('disableToolbar', ref(false))
 </script>
 
 <template>


### PR DESCRIPTION
```html
 <VuetifyTiptap
    v-model="interceptor"
    :extensions="extensions"
    :disabled="foo"
    :disable-toolbar="foo"
  />
  {{ foo }}
  <VBtn @click="foo = !foo">Toggle</VBtn>
```

`const foo = ref(false)`

When ran like this, VuetifyTiptap doesn't respect changing `foo` (`disabled` does)

This occurs because `provide('disableToolbar', props.disableToolbar)` passes the primitive `true/false` value, rather than a reactive value

`const disableToolbar = inject<boolean>('disableToolbar', false)` removes the default value. This is because `undefined` will be it's falsy replacement. Since we don't want to match types and create another `ref` we just use undefined

I was having an issue with the dev server, so I didn't test this. It seemed like a straightforward change, sorry.